### PR TITLE
ICM-423 Remove restriction to work with Puppet 5

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -43,7 +43,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
In order to be able to upgrade to Puppet agent version 5,
we need to remove this module's restriction.

It appears to be working fine in the tests.